### PR TITLE
Stop escaping > in text nodes

### DIFF
--- a/hotmeal-wasm/src/lib.rs
+++ b/hotmeal-wasm/src/lib.rs
@@ -806,12 +806,7 @@ fn serialize_insert_content(out: &mut String, content: &InsertContent) {
             out.push('>');
         }
         InsertContent::Text(text) => {
-            out.push_str(
-                &text
-                    .replace('&', "&amp;")
-                    .replace('<', "&lt;")
-                    .replace('>', "&gt;"),
-            );
+            out.push_str(&text.replace('&', "&amp;").replace('<', "&lt;"));
         }
         InsertContent::Comment(text) => {
             out.push_str("<!--");

--- a/hotmeal/fuzz/fuzz_targets/common/dom_generator.rs
+++ b/hotmeal/fuzz/fuzz_targets/common/dom_generator.rs
@@ -1570,9 +1570,7 @@ struct AttrValue(
 
 // Helper functions
 fn html_escape_text(s: &str) -> String {
-    s.replace('&', "&amp;")
-        .replace('<', "&lt;")
-        .replace('>', "&gt;")
+    s.replace('&', "&amp;").replace('<', "&lt;")
 }
 
 fn html_escape_attr(s: &str) -> String {

--- a/hotmeal/src/dom.rs
+++ b/hotmeal/src/dom.rs
@@ -834,7 +834,6 @@ impl<'a> Document<'a> {
                     match c {
                         '&' => out.push_str("&amp;"),
                         '<' => out.push_str("&lt;"),
-                        '>' => out.push_str("&gt;"),
                         _ => out.push(c),
                     }
                 }
@@ -1983,7 +1982,7 @@ mod tests {
         let doc = parse(&html);
         assert_eq!(
             doc.to_html(),
-            "<html><head></head><body><div>&lt;script&gt; &amp; \"quotes\"</div></body></html>"
+            "<html><head></head><body><div>&lt;script> &amp; \"quotes\"</div></body></html>"
         );
     }
 
@@ -2106,8 +2105,20 @@ mod tests {
         let output = doc.to_html();
 
         assert!(
-            output.contains("1 &lt; 2 &amp; 3 &gt; 1"),
+            output.contains("1 &lt; 2 &amp; 3 > 1"),
             "Normal text should be escaped. Got: {}",
+            output
+        );
+    }
+
+    #[test]
+    fn test_gt_not_escaped_in_text_nodes() {
+        let html = t("<pre>[*] --> Foo</pre>");
+        let doc = parse(&html);
+        let output = doc.to_html();
+        assert!(
+            output.contains("[*] --> Foo"),
+            "Greater-than should not be escaped in text nodes. Got: {}",
             output
         );
     }


### PR DESCRIPTION
Fixes #33.

## Summary

The HTML5 serialization spec only requires escaping `&` and `<` in text nodes. Hotmeal was also escaping `>` to `&gt;`, which is unnecessary and breaks tools like mermaid.js that read `innerHTML` of `<pre>` elements expecting literal `-->` syntax.

## Changes

- Remove `>` escaping from `Document::to_html()` in `hotmeal/src/dom.rs`
- Remove `>` escaping from WASM patch serializer in `hotmeal-wasm/src/lib.rs`
- Remove `>` escaping from fuzzer's `html_escape_text` helper
- Update existing test expectations to reflect unescaped `>`
- Add a new test `test_gt_not_escaped_in_text_nodes` for the `-->` case

## Testing

- Existing tests updated and passing
- New targeted test verifies `[*] --> Foo` round-trips without escaping `>`